### PR TITLE
Use main branch of alphafold repo with bug fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "tools/alphafold-v2.3.2"]
 	path = tools/alphafold-v2.3.2
 	url = https://github.com/google-deepmind/alphafold
-	branch = v2.3.2
+	branch = main


### PR DESCRIPTION
The branch v2.3.2 in the submodule "tools/alphafold-v2.3.2" has a broken link (the "download_uniref90.sh" script) and the download of the uniref90 database fails. This bug has been fixed in the alphafold main branch. I edited the submodule to point to the alphafold main branch.